### PR TITLE
Parameterization method, to calibrate xslt-quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ A subset of this code is a revision of code written by [Mukul Gandhi in his XSL 
 
 All other code is released under Apache License Version 2.0
 
+## Customization
+
+Not every XSLT programmer has the same needs or styles. You can calibrate the types of tests that are run by adding `{https://github.com/mricaud/xsl-quality}parameters` as a 2nd-level element in your stylesheet, with children specifying which parameters to use. An example:
+```
+<xslq:parameters>
+      <xslq:granular-template-threshold>5</xslq:granular-template-threshold>      
+      <xslq:use-oxygen-documentation>false</xslq:use-oxygen-documentation>
+      <xslq:check-global-parameters-and-variables>false</xslq:check-global-parameters-and-variables>
+      <xslq:allow-no-namespace>true</xslq:allow-no-namespace>
+</xslq:parameters>
+```
+
+You may place that element anywhere in the stylesheet you want, at the beginning, the end, or the middle, but it must be a child of the root element `xsl:transform` or `xsl:stylesheet`.
+
+If you want to see what parameters you can adjust, either consult the file [parameters.xsl](src/main/xsl/parameters.xsl) or add an element `help` or `xslq:help` to `xslq:parameters`. If you are working within Oxygen, you will see a red light bulb to the left of the error message, populated with quick fixes, to add a parameter, with its default value.
+
+Parameters are inheritable from any inclusions or imports, so you can specify your settings in a core XSLT file. Those inherited settings can be overwritten in a local XSLT file. In case multiple parameter settings are present, priority will be assigned to local settings before inherited, and then to the last parameter setting. That is, if a stylesheet inherits XSLQ settings from imported stylesheets A and B (with A imported before B), then B's settings will overrule any settings in A.  
+
+
 ## Technical notes
 
 ### Modularization 

--- a/src/main/sch/modules/xslt-quality_documentation.sch
+++ b/src/main/sch/modules/xslt-quality_documentation.sch
@@ -4,6 +4,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
   xmlns:saxon="http://saxon.sf.net/"
+  xmlns:xslq="https://github.com/mricaud/xsl-quality"
   xml:lang="en"
   id="xslt-quality_documentation">
   
@@ -13,13 +14,13 @@
     </xd:desc>
   </xd:doc>
   
-  <rule context="/xsl:stylesheet">
+  <rule context="/xsl:stylesheet | xsl:transform">
     <xd:doc>
       <xd:desc xml:lang="en">Indicate what your XSLT is doing as a minimal documentation set. When your XSLT performs a transformation (not a library) you could also describe the data expected as input, and the data generated as output.</xd:desc>
       <xd:desc xml:lang="fr">Indiquer ce que votre XSLT fait comme documentation minimale. Si votre XSLT effectue une transformation (à l'opposé d'une librairie) vous pourriez indiquer les données attendues en entrée et celles qui seront générées en sortie.</xd:desc>
     </xd:doc>
-    <assert test="xd:doc[@scope = 'stylesheet']" id="xslt-quality_documentation-stylesheet">
-      [documentation] Please add a documentation block for the whole stylesheet : &lt;xd:doc scope="stylesheet">
+    <assert test="not($xslq:use-oxygen-documentation) or xd:doc[@scope = 'stylesheet']" id="xslt-quality_documentation-stylesheet">
+      [documentation] Please add a documentation block for the whole stylesheet: &lt;xd:doc scope="stylesheet">
     </assert>
   </rule>
   

--- a/src/main/sch/modules/xslt-quality_namespaces.sch
+++ b/src/main/sch/modules/xslt-quality_namespaces.sch
@@ -9,7 +9,7 @@
   
   <xd:doc>
     <xd:desc>
-      <xd:p>These rules are about namespaces usage in XSLT</xd:p>
+      <xd:p>These rules are about namespace usage in XSLT</xd:p>
     </xd:desc>
   </xd:doc>
   
@@ -18,7 +18,7 @@
       <xd:desc xml:lang="en">Adding a namespace prefix at your global variables and parameters will make your XSLT more portable: it will avoid name conflict with other XSLT importing yours and vice versa.</xd:desc>
       <xd:desc xml:lang="fr">Ajouter un préfixe de namespace sur vos variables et paramètres globaux rendra votre XSLT plus portable : cela évitera les conflit de nommage avec d'autres XSLT qui importerait la votre et vice versa</xd:desc>
     </xd:doc>
-    <assert test="every $name in tokenize(., '\s+') satisfies matches($name, concat('^', $NCNAME.reg, ':'))" role="warning" id="xslt-quality_ns-global-statements-need-prefix">
+    <assert test="$xslq:allow-no-namespace or (every $name in tokenize(., '\s+') satisfies matches($name, concat('^', $NCNAME.reg, ':')))" role="warning" id="xslt-quality_ns-global-statements-need-prefix">
       [namespaces] <value-of select="local-name(parent::*)"/> <name/>="<value-of select="tokenize(., '\s+')[not(matches(., concat('^', $NCNAME.reg, ':')))]"/>" should be namespaces prefixed, so they don't generate conflict with imported XSLT (or when this xslt is imported)
     </assert>
   </rule>
@@ -28,7 +28,7 @@
       <xd:desc xml:lang="en">Adding a namespace prefix at your template's mode will make your XSLT more portable: it will avoid name conflict with other XSLT importing yours and vice versa.</xd:desc>
       <xd:desc xml:lang="fr">Ajouter un préfixe de namespace sur vos mode de template rendra votre XSLT plus portable : cela évitera les conflit de nommage avec d'autres XSLT qui importerait la votre et vice versa</xd:desc>
     </xd:doc>
-    <assert test="every $name in tokenize(., '\s+') satisfies matches($name, concat('^', $NCNAME.reg, ':'))" role="warning" id="xslt-quality_ns-mode-statements-need-prefix">
+    <assert test="$xslq:allow-no-namespace or (every $name in tokenize(., '\s+') satisfies matches($name, concat('^', $NCNAME.reg, ':')))" role="warning" id="xslt-quality_ns-mode-statements-need-prefix">
       [namespaces] <value-of select="local-name(parent::*)"/> @<name/> value "<value-of select="tokenize(., '\s+')[not(matches(., concat('^', $NCNAME.reg, ':')))]"/>" should be namespaces prefixed, so they don't generate conflict with imported XSLT (or when this xslt is imported)
     </assert>
   </rule>

--- a/src/main/sch/modules/xslt-quality_parameters.sch
+++ b/src/main/sch/modules/xslt-quality_parameters.sch
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pattern xmlns="http://purl.oclc.org/dsdl/schematron" 
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+  xmlns:xslq="https://github.com/mricaud/xsl-quality"
+  xmlns:saxon="http://saxon.sf.net/"
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
+  xml:lang="en"
+  id="xslt-quality_parameters">
+  
+  <xd:doc>
+    <xd:desc>
+      <xd:p>These rules are about parameters to calibrate the rules applied by XSLQ</xd:p>
+    </xd:desc>
+  </xd:doc>
+  
+  
+  
+  <rule context="/*/xslq:parameters">
+    <xd:doc>
+      <xd:desc xml:lang="en">Add parameter values.</xd:desc>
+    </xd:doc>
+    <report test="not(*)" id="xslt-quality_empty-parameters" sqf:fix="sqf_parameters">
+      [parameters] Add children elements specifying parameters, with their value as text nodes
+      inside. </report>
+    
+    <xd:doc>
+      <xd:desc xml:lang="en">See if the user needs help.</xd:desc>
+    </xd:doc>
+    <report test="exists(help) or exists(xslq:help)" sqf:fix="sqf_parameters">
+      [parameters] [help] Try one of the following parameters: 
+      <value-of select="string-join($xslq:xslq.parameters.unused/@name, ', ')"/>
+    </report>
+    
+    
+    <sqf:group id="sqf_parameters">
+      <sqf:fix id="sqf_add-parameters" use-for-each="1 to count($xslq:xslq.parameters.unused)">
+        <sqf:description>
+          <sqf:title>Add parameter <sch:value-of select="$xslq:xslq.parameters.unused[$sqf:current]/@name"/>
+          </sqf:title>
+        </sqf:description>
+        <!-- Move the final white space to after the new element -->
+        <sqf:delete match="text()[last()][not(matches(., '\S'))]"/>
+        <sqf:add match="." position="last-child">
+          <!-- Imitate the indentation of the document -->
+          <xsl:value-of select="$xslq:self.indentations.typical[2]"/>
+          <xsl:element name="{$xslq:xslq.parameters.unused[$sqf:current]/@name}">
+            <xsl:value-of
+              select="replace(tokenize($xslq:xslq.parameters.unused[$sqf:current]/@select, ' +')[last()], '\(\)', '')"/>
+          </xsl:element>
+          <xsl:value-of select="text()[last()][not(matches(., '\S'))]"/>
+        </sqf:add>
+      </sqf:fix>
+    </sqf:group>
+  </rule>
+  
+  <rule context="/*/xslq:parameters/*">
+    <let name="this-name" value="name(.)"/>
+    <let name="this-corresponding-xslq-param"
+      value="$xslq:xslq-parameter-file/*/xsl:param[@name eq $this-name]"/>
+    <let name="expected-data-type" value="$this-corresponding-xslq-param/@as"/>
+    <let name="this-value-is-castable" value="xslq:data-type-check(., $expected-data-type)"/>
+    <xd:doc>
+      <xd:desc xml:lang="en">Check for parameters with the wrong name.</xd:desc>
+    </xd:doc>
+    <assert test="exists($this-corresponding-xslq-param)" sqf:fix="sqf_del_element">
+      [parameters] Children elements of xslq:parameters must have a name that matches
+      a global parameter.
+    </assert>
+    <assert test="$this-value-is-castable" sqf:fix="sqf_del_element">
+      [parameters] <value-of select="name(.)"/> must be castable as <value-of select="$expected-data-type"/>
+    </assert>
+    
+    <sqf:fix id="sqf_del_element">
+      <sqf:description>
+        <sqf:title>Delete current element</sqf:title>
+      </sqf:description>
+      <sqf:delete/>
+    </sqf:fix>
+  </rule>
+  
+  
+</pattern>

--- a/src/main/sch/xslt-quality.sch
+++ b/src/main/sch/xslt-quality.sch
@@ -5,7 +5,7 @@
   xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
   xmlns:saxon="http://saxon.sf.net/"
   queryBinding="xslt3" 
-  id="checkXSLTstyle.sch"
+  id="xslt-quality.sch"
   >
   
   <xd:doc>
@@ -21,6 +21,7 @@
   <ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
   <ns prefix="xd" uri="http://www.oxygenxml.com/ns/doc/xsl"/>
   <ns prefix="xslq" uri="https://github.com/mricaud/xsl-quality"/>
+  <ns prefix="sqf" uri="http://www.schematron-quickfix.com/validator/process"/>
   
   <title>XSLT Quality Schematron</title>
   
@@ -47,5 +48,6 @@
   <include href="modules/xslt-quality_typing.sch"/>
   <include href="modules/xslt-quality_writing.sch"/>
   <include href="modules/xslt-quality_xslt-3.0.sch"/>
+  <include href="modules/xslt-quality_parameters.sch"/>
   
 </schema>

--- a/src/main/xsl/parameters.xsl
+++ b/src/main/xsl/parameters.xsl
@@ -1,0 +1,79 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+   xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+   xmlns:xslq="https://github.com/mricaud/xsl-quality"
+   xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+   
+   <xslq:parameters>
+      <!-- We avoid checking for used global parameters, because this stylesheet exists only to be imported. -->
+      <xslq:check-global-parameters-and-variables>false</xslq:check-global-parameters-and-variables>
+   </xslq:parameters>
+   
+   <xd:doc scope="stylesheet">
+      <xd:desc>This XSLT file is exclusively for users to be able to calibrate the way XSLT-quality
+         assesses their stylesheets. Please note, the select attribute for each parameter is set up so that the
+         default value is at the end of an if-then-else construction. This position is important, because it is
+         used by Schematron Quick Fixes to populate a user's parameter with the default value.
+      </xd:desc>
+   </xd:doc>
+   
+   <xd:doc>
+      <xd:desc>At what point should a template be regarded as a granular template? The integer is
+         interpreted as the maximum number of elements allowed in an xsl:template before it is not
+         considered granular any more.</xd:desc>
+   </xd:doc>
+   <xsl:param name="xslq:granular-template-threshold" as="xs:integer"
+      select="
+         if ($xslq:local.xslq.parameters.resolved/xslq:granular-template-threshold castable as xs:integer) then
+            xs:integer($xslq:local.xslq.parameters.resolved/xslq:granular-template-threshold)
+         else
+            3"
+   />
+   
+   <xd:doc>
+      <xd:desc>In a given XSLT file, how many granular templates should be considered too many
+         before the file becomes difficult to read?</xd:desc>
+   </xd:doc>
+   <xsl:param name="xslq:max-granular-templates-per-file" as="xs:integer"
+      select="
+         if ($xslq:local.xslq.parameters.resolved/xslq:max-granular-templates-per-file castable as xs:integer) then
+            xs:integer($xslq:local.xslq.parameters.resolved/xslq:max-granular-templates-per-file)
+         else
+            10"
+   />
+   
+   <xd:doc>
+      <xd:desc>Should XSLT files use Oxygen documentation?</xd:desc>
+   </xd:doc>
+   <xsl:param name="xslq:use-oxygen-documentation" as="xs:boolean"
+      select="
+         if ($xslq:local.xslq.parameters.resolved/xslq:use-oxygen-documentation castable as xs:boolean) then
+            xs:boolean($xslq:local.xslq.parameters.resolved/xslq:use-oxygen-documentation)
+         else
+            true()"
+   />
+
+   <xd:doc>
+      <xd:desc>Should global parameters and variables be checked for use? If the stylesheet declares
+         parameters or variables intended to be used by including/importing components, then this should 
+         be set to false.</xd:desc>
+   </xd:doc>
+   <xsl:param name="xslq:check-global-parameters-and-variables" as="xs:boolean"
+      select="
+         if ($xslq:local.xslq.parameters.resolved/xslq:check-global-parameters-and-variables castable as xs:boolean) then
+            xs:boolean($xslq:local.xslq.parameters.resolved/xslq:check-global-parameters-and-variables)
+         else
+            true()"
+   />
+
+   <xd:doc>
+      <xd:desc>Should global parameters and variables, and should template modes, be allowed to inhabit
+      no namespace?</xd:desc>
+   </xd:doc>
+   <xsl:param name="xslq:allow-no-namespace" as="xs:boolean"
+      select="
+         if ($xslq:local.xslq.parameters.resolved/xslq:allow-no-namespace castable as xs:boolean) then
+            xs:boolean($xslq:local.xslq.parameters.resolved/xslq:allow-no-namespace)
+         else
+            false()"
+   />
+</xsl:stylesheet>

--- a/src/test/sample-lib.xsl
+++ b/src/test/sample-lib.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="../main/sch/checkXSLTstyle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../main/sch/xslt-quality.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   exclude-result-prefixes="xs"

--- a/src/test/sample.xslt-2.0.xsl
+++ b/src/test/sample.xslt-2.0.xsl
@@ -17,7 +17,7 @@
   
   <!--<xd:doc scope="stylesheet">
     <xd:desc>
-      <xd:p>Sample XSLT to test validatation with checkXSLTstyle.sch</xd:p>
+      <xd:p>Sample XSLT to test validatation with xslt-quality.sch</xd:p>
     </xd:desc>
   </xd:doc>-->
   

--- a/src/test/sample.xslt-3.0.xsl
+++ b/src/test/sample.xslt-3.0.xsl
@@ -19,7 +19,7 @@
   
   <xd:doc scope="stylesheet">
     <xd:desc>
-      <xd:p>This is a XSLT 3.0 sample so we can focus on schematron rules adapted to XSLT 3.0 with checkXSLTstyle.sch</xd:p>
+      <xd:p>This is a XSLT 3.0 sample so we can focus on schematron rules adapted to XSLT 3.0 with xslt-quality.sch</xd:p>
     </xd:desc>
   </xd:doc>
   

--- a/xslt-quality.xpr
+++ b/xslt-quality.xpr
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project version="20.1">
+<project version="22.1">
     <meta>
         <filters directoryPatterns="" filePatterns="xslt-quality.xpr" positiveFilePatterns="" showHiddenFiles="false"/>
         <options>
-            <serialized version="20.1" xml:space="preserve">
+            <serialized version="22.1" xml:space="preserve">
                 <serializableOrderedMap>
                     <entry>
                         <String>enable.project.master.files.support</String>
@@ -24,6 +24,31 @@
                                 <field name="scenarioTypes">
                                     <list>
                                         <String>Validation_scenario</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioStorageLocations">
+                                    <list>
+                                        <Byte>2</Byte>
+                                    </list>
+                                </field>
+                            </scenarioAssociation>
+                            <scenarioAssociation>
+                                <field name="url">
+                                    <String>src/main/xsl/parameters.xsl</String>
+                                </field>
+                                <field name="scenarioIds">
+                                    <list>
+                                        <String>XSLT quality</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioTypes">
+                                    <list>
+                                        <String>Validation_scenario</String>
+                                    </list>
+                                </field>
+                                <field name="scenarioStorageLocations">
+                                    <list>
+                                        <Byte>2</Byte>
                                     </list>
                                 </field>
                             </scenarioAssociation>
@@ -74,7 +99,7 @@
                                                         <Integer>7</Integer>
                                                     </field>
                                                     <field name="uri">
-                                                        <String>${pdu}/src/main/sch/checkXSLTstyle.sch</String>
+                                                        <String>${pdu}/src/main/sch/xslt-quality.sch</String>
                                                     </field>
                                                 </validationUnitSchema>
                                             </field>
@@ -97,6 +122,7 @@
     <projectTree name="xslt-quality.xpr">
         <folder masterFiles="true" name="Master Files">
             <file name="src/main/sch/xslt-quality.sch"/>
+            <file name="src/main/xsl/xslt-quality.xsl"/>
         </folder>
         <folder path="."/>
     </projectTree>


### PR DESCRIPTION
@mricaud The most recent commit of my fork allows users to insert parameters directly into their stylesheet, to calibrate exactly the level of quality tests. Start with the readme file, since there's a new section that explains how to customize things.

I have done only simple unit testing, enough to know that it works locally on a couple of XSLT files. The next step will be to try to apply this to sets of included/imported stylesheets.

Note too that this is the first time that Schematron Quick Fixes have been introduced. If SQFs get reused, the structure will likely change, to avoid repetition. 

Don't hesitate to let me know where you think I've gone wrong.